### PR TITLE
Extended the BasicNMEAHandler to return all parsed info

### DIFF
--- a/src/main/java/com/github/petr_s/nmea/NMEAParser.java
+++ b/src/main/java/com/github/petr_s/nmea/NMEAParser.java
@@ -117,7 +117,7 @@ public class NMEAParser implements BasicNMEAHandler {
     }
 
     @Override
-    public synchronized void onRMC(long date, long time, double latitude, double longitude, float speed, float direction) {
+    public synchronized void onRMC(long date, long time, double latitude, double longitude, float speed, float direction, Float magVar, String magVarDir, String faa, boolean isGN) {
         newLocation(time);
 
         location.setTime(date | time);
@@ -128,7 +128,7 @@ public class NMEAParser implements BasicNMEAHandler {
     }
 
     @Override
-    public synchronized void onGGA(long time, double latitude, double longitude, float altitude, FixQuality quality, int satellites, float hdop) {
+    public synchronized void onGGA(long time, double latitude, double longitude, float altitude, FixQuality quality, int satellites, float hdop, Float age, Integer station, boolean isGN) {
         newLocation(time);
 
         location.setLatitude(latitude);
@@ -147,7 +147,7 @@ public class NMEAParser implements BasicNMEAHandler {
     }
 
     @Override
-    public void onGSA(FixType type, Set<Integer> prns, float pdop, float hdop, float vdop) {
+    public void onGSA(String mode, FixType type, Set<Integer> prns, float pdop, float hdop, float vdop) {
         activeSatellites = prns;
 
         yieldSatellites();

--- a/src/main/java/com/github/petr_s/nmea/basic/BasicNMEAAdapter.java
+++ b/src/main/java/com/github/petr_s/nmea/basic/BasicNMEAAdapter.java
@@ -9,12 +9,12 @@ public class BasicNMEAAdapter implements BasicNMEAHandler {
     }
 
     @Override
-    public void onRMC(long date, long time, double latitude, double longitude, float speed, float direction) {
+    public void onRMC(long date, long time, double latitude, double longitude, float speed, float direction, Float magVar, String magVarDir, String modeInc, boolean isGN) {
 
     }
 
     @Override
-    public void onGGA(long time, double latitude, double longitude, float altitude, FixQuality quality, int satellites, float hdop) {
+    public void onGGA(long time, double latitude, double longitude, float altitude, FixQuality quality, int satellites, float hdop, Float age, Integer station, boolean isGN) {
 
     }
 
@@ -24,7 +24,7 @@ public class BasicNMEAAdapter implements BasicNMEAHandler {
     }
 
     @Override
-    public void onGSA(FixType type, Set<Integer> prns, float pdop, float hdop, float vdop) {
+    public void onGSA(String mode, FixType type, Set<Integer> prns, float pdop, float hdop, float vdop) {
 
     }
 

--- a/src/main/java/com/github/petr_s/nmea/basic/BasicNMEAHandler.java
+++ b/src/main/java/com/github/petr_s/nmea/basic/BasicNMEAHandler.java
@@ -6,7 +6,7 @@ public interface BasicNMEAHandler {
     void onStart();
 
     /***
-     * Called on GPRMC parsed.
+     * Called on GPRMC and GNRMC parsed.
      *
      * @param date      milliseconds since midnight, January 1, 1970 UTC.
      * @param time      actual UTC time (without date)
@@ -14,11 +14,15 @@ public interface BasicNMEAHandler {
      * @param longitude angular x position on the Earth.
      * @param speed     in meters per second.
      * @param direction angular bearing value to the North.
+     * @param magVar    magnetic variation, degrees. Note: that this field is the actual magnetic variation and will always be positive.
+     * @param magVarDir direction of magnetic variation E/W: Easterly variation (E) subtracts from True course, Westerly variation (W) adds to True course.
+     * @param modeInc   positioning system mode indicator: A - Autonomous, D - Differential, E - Estimated (dead reckoning) mode, M - Manual input, N - Data not valid
+     * @param isGN      returns true if sentence was GNRMC, false is sentence was GPRMC
      */
-    void onRMC(long date, long time, double latitude, double longitude, float speed, float direction);
+    void onRMC(long date, long time, double latitude, double longitude, float speed, float direction, Float magVar, String magVarDir, String modeInc, boolean isGN);
 
     /***
-     * Called on GPGGA parsed.
+     * Called on GPGGA and GNGGA parsed.
      *
      * @param time        actual UTC time (without date)
      * @param latitude    angular y position on the Earth.
@@ -27,8 +31,10 @@ public interface BasicNMEAHandler {
      * @param quality     fix-quality type {@link FixQuality}
      * @param satellites  actual number of satellites
      * @param hdop        horizontal dilution of precision
+     * @param age         age
+     * @param isGN        returns true if sentence was GNGGA, false is sentence was GPGGA
      */
-    void onGGA(long time, double latitude, double longitude, float altitude, FixQuality quality, int satellites, float hdop);
+    void onGGA(long time, double latitude, double longitude, float altitude, FixQuality quality, int satellites, float hdop, Float age, Integer station, boolean isGN);
 
     /***
      * Called on GPGSV parsed.
@@ -46,13 +52,14 @@ public interface BasicNMEAHandler {
     /***
      * Called on GPGSA parsed.
      *
+     * @param mode where the mode of operation is automatically or manually set, A = Automatic 2D/3D, M = Manual, forced to operate in 2D or 3D
      * @param type type of fix
      * @param prns set of satellites used for the current fix
      * @param pdop position dilution of precision
      * @param hdop horizontal dilution of precision
      * @param vdop vertical dilution of precision
      */
-    void onGSA(FixType type, Set<Integer> prns, float pdop, float hdop, float vdop);
+    void onGSA(String mode, FixType type, Set<Integer> prns, float pdop, float hdop, float vdop);
 
     void onUnrecognized(String sentence);
 

--- a/src/main/java/com/github/petr_s/nmea/basic/BasicNMEAParser.java
+++ b/src/main/java/com/github/petr_s/nmea/basic/BasicNMEAParser.java
@@ -350,7 +350,7 @@ public class BasicNMEAParser {
         S,
     }
 
-    public enum Mode {
+    private enum Mode {
         A,
         M
     }

--- a/src/test/java/com/github/petr_s/nmea/basic/BasicNMEAParserTest.java
+++ b/src/test/java/com/github/petr_s/nmea/basic/BasicNMEAParserTest.java
@@ -53,7 +53,11 @@ public class BasicNMEAParserTest {
                 doubleThat(roughlyEq(50.07914)),
                 doubleThat(roughlyEq(14.39825)),
                 floatThat(roughlyEq(0.02057f)),
-                floatThat(roughlyEq(36.97f)));
+                floatThat(roughlyEq(36.97f)),
+                isNull(Float.class),
+                isNull(String.class),
+                isNull(String.class),
+                eq(false));
         verify(handler).onFinished();
         verifyNoMoreInteractions(handler);
     }
@@ -69,7 +73,11 @@ public class BasicNMEAParserTest {
                 doubleThat(roughlyEq(50.075415)),
                 doubleThat(roughlyEq(14.404795)),
                 floatThat(roughlyEq(0.142501f)),
-                floatThat(roughlyEq(0.0f)));
+                floatThat(roughlyEq(0.0f)),
+                isNull(Float.class),
+                isNull(String.class),
+                eq("A"),
+                eq(false));
         verify(handler).onFinished();
         verifyNoMoreInteractions(handler);
     }
@@ -85,7 +93,11 @@ public class BasicNMEAParserTest {
                 doubleThat(roughlyEq(50.07914)),
                 doubleThat(roughlyEq(14.39825)),
                 floatThat(roughlyEq(0.02057f)),
-                floatThat(roughlyEq(36.97f)));
+                floatThat(roughlyEq(36.97f)),
+                isNull(Float.class),
+                isNull(String.class),
+                isNull(String.class),
+                eq(true));
         verify(handler).onFinished();
         verifyNoMoreInteractions(handler);
     }
@@ -124,7 +136,10 @@ public class BasicNMEAParserTest {
                 floatThat(roughlyEq(240.2f)),
                 eq(BasicNMEAHandler.FixQuality.GPS),
                 eq(7),
-                floatThat(roughlyEq(1.7f)));
+                floatThat(roughlyEq(1.7f)),
+                isNull(Float.class),
+                eq(0),
+                eq(false));
         verify(handler).onFinished();
         verifyNoMoreInteractions(handler);
     }
@@ -141,7 +156,10 @@ public class BasicNMEAParserTest {
                 floatThat(roughlyEq(240.2f)),
                 eq(BasicNMEAHandler.FixQuality.GPS),
                 eq(7),
-                floatThat(roughlyEq(1.7f)));
+                floatThat(roughlyEq(1.7f)),
+                isNull(Float.class),
+                eq(0),
+                eq(true));
         verify(handler).onFinished();
         verifyNoMoreInteractions(handler);
     }
@@ -158,7 +176,10 @@ public class BasicNMEAParserTest {
                 floatThat(roughlyEq(128.2f)),
                 eq(BasicNMEAHandler.FixQuality.GPS),
                 eq(11),
-                floatThat(roughlyEq(0.6f)));
+                floatThat(roughlyEq(0.6f)),
+                isNull(Float.class),
+                isNull(Integer.class),
+                eq(false));
         verify(handler).onFinished();
         verifyNoMoreInteractions(handler);
     }
@@ -281,7 +302,8 @@ public class BasicNMEAParserTest {
         new BasicNMEAParser(handler).parse(sentence);
 
         verify(handler).onStart();
-        verify(handler).onGSA(eq(Fix3D),
+        verify(handler).onGSA(eq("A"),
+                eq(Fix3D),
                 argThat(eq(new HashSet<>(Arrays.asList(new Integer[]{2, 5, 21, 25, 26, 12, 29, 31})))),
                 floatThat(roughlyEq(1.6f)),
                 floatThat(roughlyEq(1.0f)),


### PR DESCRIPTION
Closes #5 

This required extending the NMEAParser interface to include all parsed fields from the NMEA sentence. This will definitely break backwards compatibility for devs currently using 0.5.0. (Not sure how many people that actually is)

onRMC now also returns magnetic variation, mag-var direction,  mode indicator and a boolean `isGN` which is true is the source sentence was GNRMC

onGGA now also returns age, station, and a boolean `isGN` which is true is the source sentence was GNGGA

onGSA now also returns a string `mode` where, A = Automatic 2D/3D, M = Manual, forced to operate in 2D or 3D

All changes also apply to `BasicNMEAAdapter` and `BasicNMEAHandler`